### PR TITLE
Add category navigation and filtering

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import SignupPage from './pages/SignupPage';
 import AdminProductsPage from './pages/AdminProductsPage';
 import AdminOrdersPage from './pages/AdminOrdersPage';
 import ProductsPage from './pages/ProductsPage'; // <-- Use this instead of CatalogPage
+import CategoryPage from './pages/CategoryPage';
 
 const ProtectedAdmin = ({ children }) => {
   const { user } = React.useContext(AuthContext);
@@ -33,6 +34,7 @@ export default function App() {
                   <Route path="/" element={<HomePage />} />
                   <Route path="/products" element={<ProductsPage />} /> {/* Updated */}
                   <Route path="/products/:productId" element={<ProductPage />} />
+                  <Route path="/category/:tag" element={<CategoryPage />} />
                   <Route path="/cart" element={<CartPage />} />
                   <Route path="/checkout" element={<CheckoutPage />} />
                   <Route path="/login" element={<LoginPage />} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -29,6 +29,30 @@ export default function Header() {
             Shop
           </Link>
           <Link
+            to="/category/sun-glasses"
+            className="text-white hover:text-brand-primary transition-colors"
+          >
+            Sun Glasses
+          </Link>
+          <Link
+            to="/category/men"
+            className="text-white hover:text-brand-primary transition-colors"
+          >
+            Men
+          </Link>
+          <Link
+            to="/category/women"
+            className="text-white hover:text-brand-primary transition-colors"
+          >
+            Women
+          </Link>
+          <Link
+            to="/category/lens"
+            className="text-white hover:text-brand-primary transition-colors"
+          >
+            Lens
+          </Link>
+          <Link
             to="/cart"
             className="text-white hover:text-brand-primary transition-colors relative"
           >
@@ -74,6 +98,34 @@ export default function Header() {
                 onClick={() => setMenuOpen(false)}
               >
                 Shop
+              </Link>
+              <Link
+                to="/category/sun-glasses"
+                className="text-white hover:text-brand-primary transition-colors"
+                onClick={() => setMenuOpen(false)}
+              >
+                Sun Glasses
+              </Link>
+              <Link
+                to="/category/men"
+                className="text-white hover:text-brand-primary transition-colors"
+                onClick={() => setMenuOpen(false)}
+              >
+                Men
+              </Link>
+              <Link
+                to="/category/women"
+                className="text-white hover:text-brand-primary transition-colors"
+                onClick={() => setMenuOpen(false)}
+              >
+                Women
+              </Link>
+              <Link
+                to="/category/lens"
+                className="text-white hover:text-brand-primary transition-colors"
+                onClick={() => setMenuOpen(false)}
+              >
+                Lens
               </Link>
               <Link
                 to="/cart"

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -1,0 +1,35 @@
+import React, { memo } from 'react';
+import { Link } from 'react-router-dom';
+import { formatCurrency } from '../utils/utils';
+
+const ProductCard = memo(({ product }) => (
+  <div className="bg-white rounded-xl shadow-soft hover:shadow-glow transition-shadow duration-300 flex flex-col overflow-hidden">
+    <div className="border-t-2 border-brand-gold" />
+    <div className="p-4">
+      <div className="h-48 w-full mb-4">
+        <img
+          src={product.images[0]}
+          alt={product.name}
+          loading="lazy"
+          className="w-full h-48 object-cover rounded-lg mb-4"
+          onError={e => { e.target.src = 'https://via.placeholder.com/200x150?text=No+Image'; }}
+        />
+      </div>
+      <h2 className="text-xl font-semibold mb-2 text-brand-darkText">{product.name}</h2>
+      <p className="text-brand-darkText/70 flex-1 mb-4">{product.description}</p>
+      <div className="mt-auto">
+        <div className="text-lg font-bold text-brand-primary mb-3">
+          {formatCurrency(product.price)}
+        </div>
+        <Link
+          to={`/products/${product.id}`}
+          className="w-full inline-flex justify-center items-center px-4 py-2 bg-brand-primary text-brand-lightText rounded-xl hover:bg-white hover:text-brand-primary border-2 border-transparent hover:border-brand-primary transition-colors duration-300"
+        >
+          View Details
+        </Link>
+      </div>
+    </div>
+  </div>
+));
+
+export default ProductCard;

--- a/src/data/products.js
+++ b/src/data/products.js
@@ -8,6 +8,7 @@ export const products = [
     description: "Timeless round metal frames with premium finish. Perfect for both formal and casual occasions. Features anti-glare coating and UV protection.",
     price: 7999,
     images: [pd01],
+    tags: ['sun-glasses', 'men'],
     features: [
       "Premium metal construction",
       "Anti-glare coating",
@@ -30,6 +31,7 @@ export const products = [
     description: "Contemporary square frames crafted from premium Italian acetate. Features blue light filtering and comes with a designer case.",
     price: 9999,
     images: [pd02],
+    tags: ['sun-glasses', 'women', 'lens'],
     features: [
       "Italian acetate material",
       "Blue light filtering",

--- a/src/pages/CategoryPage.jsx
+++ b/src/pages/CategoryPage.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { products } from '../data/products';
+import { Glasses } from 'lucide-react';
+import ProductCard from '../components/ProductCard';
+
+export default function CategoryPage() {
+  const { tag } = useParams();
+  const filtered = products.filter(p => p.tags && p.tags.includes(tag));
+  const title = tag.replace(/-/g, ' ');
+
+  return (
+    <div className="container mx-auto px-4">
+      <h1 className="flex items-center justify-center gap-2 text-3xl font-extrabold mb-8 text-center text-brand-blue drop-shadow">
+        <Glasses size={32} className="text-brand-gold" />
+        {title.charAt(0).toUpperCase() + title.slice(1)}
+      </h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+        {filtered.map(product => (
+          <ProductCard key={product.id} product={product} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -1,39 +1,7 @@
-import React, { memo } from 'react';
-import { Link } from 'react-router-dom';
+import React from 'react';
 import { products } from '../data/products';
-import { formatCurrency } from '../utils/utils';
 import { Glasses } from 'lucide-react';
-
-// Create a memoized product card component
-const ProductCard = memo(({ product }) => (
-  <div className="bg-white rounded-xl shadow-soft hover:shadow-glow transition-shadow duration-300 flex flex-col overflow-hidden">
-    <div className="border-t-2 border-brand-gold" />
-    <div className="p-4">
-      <div className="h-48 w-full mb-4">
-      <img
-        src={product.images[0]}
-        alt={product.name}
-        loading="lazy"
-        className="w-full h-48 object-cover rounded-lg mb-4"
-        onError={e => { e.target.src = 'https://via.placeholder.com/200x150?text=No+Image'; }}
-      />
-      </div>
-      <h2 className="text-xl font-semibold mb-2 text-brand-darkText">{product.name}</h2>
-      <p className="text-brand-darkText/70 flex-1 mb-4">{product.description}</p>
-      <div className="mt-auto">
-        <div className="text-lg font-bold text-brand-primary mb-3">
-          {formatCurrency(product.price)}
-        </div>
-        <Link
-          to={`/products/${product.id}`}
-          className="w-full inline-flex justify-center items-center px-4 py-2 bg-brand-primary text-brand-lightText rounded-xl hover:bg-white hover:text-brand-primary border-2 border-transparent hover:border-brand-primary transition-colors duration-300"
-        >
-          View Details
-        </Link>
-      </div>
-    </div>
-  </div>
-));
+import ProductCard from '../components/ProductCard';
 
 export default function ProductsPage() {
   return (


### PR DESCRIPTION
## Summary
- add categories to header and mobile menu for Sun Glasses, Men, Women, and Lens
- tag products and display category-specific product lists via a new CategoryPage
- extract reusable ProductCard component for product listings

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aaff382a1c832eba92e5f044f3842a